### PR TITLE
Add `DefaultArrayInterface` methods

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,8 @@ repos:
   - id: check-yaml
   - id: end-of-file-fixer
     exclude_types: [markdown]  # incompatible with Literate.jl
-- repo: https://github.com/qiaojunfeng/pre-commit-julia-format
-  rev: v0.2.0
+
+- repo: "https://github.com/domluna/JuliaFormatter.jl"
+  rev: v1.0.62  
   hooks:
-  - id: julia-format
+  - id: "julia-formatter"

--- a/Project.toml
+++ b/Project.toml
@@ -14,22 +14,9 @@ TypeParameterAccessors = "7e5a90cf-f82e-492e-a09b-e3e26432c138"
 
 [compat]
 Adapt = "4.1.1"
-Aqua = "0.8.9"
 ArrayLayouts = "1.11.0"
 ExproniconLite = "0.10.13"
 LinearAlgebra = "1.10"
 MLStyle = "0.4.17"
 MapBroadcast = "0.1.5"
-SafeTestsets = "0.1"
-Suppressor = "0.2"
-Test = "1.10"
 julia = "1.10"
-
-[extras]
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
-Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Aqua", "Test", "Suppressor", "SafeTestsets"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DerivableInterfaces"
 uuid = "6c5e35bf-e59e-4898-b73c-732dcc4ba65f"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.3.7"
+version = "0.3.8"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/defaultarrayinterface.jl
+++ b/src/defaultarrayinterface.jl
@@ -6,3 +6,27 @@ function interface(a::Type{<:AbstractArray})
   parenttype(a) === a && return DefaultArrayInterface()
   return interface(parenttype(a))
 end
+
+@interface ::DefaultArrayInterface function Base.getindex(
+  a::AbstractArray{<:Any,N}, I::Vararg{Int,N}
+) where {N}
+  return Base.getindex(a, I...)
+end
+
+@interface ::DefaultArrayInterface function Base.setindex!(
+  a::AbstractArray{<:Any,N}, value, I::Vararg{Int,N}
+) where {N}
+  return Base.setindex!(a, value, I...)
+end
+
+@interface ::DefaultArrayInterface function Base.map!(
+  f, a_dest::AbstractArray, a_srcs::AbstractArray...
+)
+  return Base.map!(f, a_dest, a_srcs...)
+end
+
+@interface ::DefaultArrayInterface function Base.mapreduce(
+  f, op, as::AbstractArray...; kwargs...
+)
+  return Base.mapreduce(f, op, as...; kwargs...)
+end

--- a/src/interface_macro.jl
+++ b/src/interface_macro.jl
@@ -80,10 +80,11 @@ DerivableInterfaces.call(SparseArrayInterface(), Base.setindex!, a, value, I...)
 ```
 =#
 function interface_setref(interface::Union{Symbol,Expr}, func::Expr)
-  func = @match func begin
-    :($a[$(I...)] = $value) => :(Base.setindex!($a, $value, $(I...)))
+  return @match func begin
+    :($a[$(I...)] = $value) => Expr(
+      :block, interface_call(interface, :(Base.setindex!($a, $value, $(I...)))), :($value)
+    )
   end
-  return interface_call(interface, func)
 end
 
 #=

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -7,3 +7,9 @@ MapBroadcast = "ebd9b9da-f48d-417c-9660-449667d60261"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+Aqua = "0.8.9"
+SafeTestsets = "0.1"
+Suppressor = "0.2"
+Test = "1.10"

--- a/test/basics/test_defaultarrayinterface.jl
+++ b/test/basics/test_defaultarrayinterface.jl
@@ -15,7 +15,7 @@ end
     @test a == A[i...]
     v = 1.1
     A′ = @inferred _setindex!(A, v, i...)
-    @test_broken A′ == (A[i...] = v) # FIXME: `setindex` and `A[i] = v` have a slight semantic difference
+    @test A′ == (A[i...] = v)
   end
 end
 

--- a/test/basics/test_defaultarrayinterface.jl
+++ b/test/basics/test_defaultarrayinterface.jl
@@ -1,0 +1,32 @@
+using Test: @testset, @test, @inferred
+using DerivableInterfaces: @interface, DefaultArrayInterface
+
+# function wrappers to test type-stability
+_getindex(A, i...) = @interface DefaultArrayInterface() A[i...]
+_setindex!(A, v, i...) = @interface DefaultArrayInterface() A[i...] = v
+_map!(args...) = @interface DefaultArrayInterface() map!(args...)
+function _mapreduce(args...; kwargs...)
+  @interface DefaultArrayInterface() mapreduce(args...; kwargs...)
+end
+
+@testset "indexing" begin
+  for (A, i) in ((zeros(2), 2), (zeros(2, 2), (2, 1)), (zeros(1, 2, 3), (1, 2, 3)))
+    a = @inferred _getindex(A, i...)
+    @test a == A[i...]
+    v = 1.1
+    A′ = @inferred _setindex!(A, v, i...)
+    @test_broken A′ == (A[i...] = v) # FIXME: `setindex` and `A[i] = v` have a slight semantic difference
+  end
+end
+
+@testset "map!" begin
+  A = zeros(3)
+  a = @inferred _map!(Returns(2), copy(A), A)
+  @test a == map!(Returns(2), copy(A), A)
+end
+
+@testset "mapreduce" begin
+  A = zeros(3)
+  a = @inferred _mapreduce(Returns(2), +, A)
+  @test a == mapreduce(Returns(2), +, A)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,31 +1,31 @@
 using SafeTestsets: @safetestset
-using Suppressor: @suppress
-using Test: @testset
+using Suppressor: Suppressor
 
-@testset "DerivableInterfaces.jl tests" begin
-  # check for filtered groups
-  # either via `--group=ALL` or through ENV["GROUP"]
-  pat = r"(?:--group=)(\w+)"
-  arg_id = findfirst(contains(pat), ARGS)
-  GROUP = uppercase(
-    if isnothing(arg_id)
-      get(ENV, "GROUP", "ALL")
-    else
-      only(match(pat, ARGS[arg_id]).captures)
-    end,
-  )
+# check for filtered groups
+# either via `--group=ALL` or through ENV["GROUP"]
+const pat = r"(?:--group=)(\w+)"
+arg_id = findfirst(contains(pat), ARGS)
+const GROUP = uppercase(
+  if isnothing(arg_id)
+    get(ENV, "GROUP", "ALL")
+  else
+    only(match(pat, ARGS[arg_id]).captures)
+  end,
+)
 
-  function istestfile(filename)
-    return isfile(filename) &&
-           endswith(filename, ".jl") &&
-           startswith(basename(filename), "test")
-  end
+"match files of the form `test_*.jl`, but exclude `*setup*.jl`"
+istestfile(fn) =
+  endswith(fn, ".jl") && startswith(basename(fn), "test_") && !contains(fn, "setup")
+"match files of the form `*.jl`, but exclude `*_notest.jl` and `*setup*.jl`"
+isexamplefile(fn) =
+  endswith(fn, ".jl") && !endswith(fn, "_notest.jl") && !contains(fn, "setup")
 
+@time begin
   # tests in groups based on folder structure
   for testgroup in filter(isdir, readdir(@__DIR__))
     if GROUP == "ALL" || GROUP == uppercase(testgroup)
       for file in filter(istestfile, readdir(joinpath(@__DIR__, testgroup); join=true))
-        @eval @safetestset $file begin
+        @eval @safetestset $(last(splitdir(file))) begin
           include($file)
         end
       end
@@ -34,7 +34,7 @@ using Test: @testset
 
   # single files in top folder
   for file in filter(istestfile, readdir(@__DIR__))
-    (file == basename(@__FILE__)) && continue
+    (file == basename(@__FILE__)) && continue # exclude this file to avoid infinite recursion
     @eval @safetestset $file begin
       include($file)
     end
@@ -42,9 +42,20 @@ using Test: @testset
 
   # test examples
   examplepath = joinpath(@__DIR__, "..", "examples")
-  for file in filter(endswith(".jl"), readdir(examplepath; join=true))
-    @suppress @eval @safetestset $file begin
-      include($file)
+  for (root, _, files) in walkdir(examplepath)
+    contains(chopprefix(root, @__DIR__), "setup") && continue
+    for file in filter(isexamplefile, files)
+      filename = joinpath(root, file)
+      @eval begin
+        @safetestset $file begin
+          $(Expr(
+            :macrocall,
+            GlobalRef(Suppressor, Symbol("@suppress")),
+            LineNumberNode(@__LINE__, @__FILE__),
+            :(include($filename)),
+          ))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds some missing implementations for `DefaultArrayInterface`, which are not defined for `AbstractArrayInterface`.

Additionally, it closes #10 to make the tests pass, and updates the skeleton to make the tests run.