### PR TITLE
Implement `_cat` instead of `cat`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DerivableInterfaces"
 uuid = "6c5e35bf-e59e-4898-b73c-732dcc4ba65f"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.3.8"
+version = "0.3.9"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/abstractarrayinterface.jl
+++ b/src/abstractarrayinterface.jl
@@ -325,7 +325,7 @@ end
   return a_dest
 end
 
-@interface interface::AbstractArrayInterface function Base.cat(as::AbstractArray...; dims)
+@interface interface::AbstractArrayInterface function Base._cat(dims, as::AbstractArray...)
   a_dest = similar(Cat(as...; dims))
   @interface interface cat!(a_dest, as...; dims)
   return a_dest

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -45,7 +45,7 @@ function derive(::Val{:AbstractArrayOps}, type)
     Base.permutedims!(::Any, ::$type, ::Any)
     Broadcast.BroadcastStyle(::Type{<:$type})
     Base.copyto!(::$type, ::Broadcast.Broadcasted{Broadcast.DefaultArrayStyle{0}})
-    Base.cat(::$type...; kwargs...)
+    Base._cat(::Any, ::$type...)
     ArrayLayouts.MemoryLayout(::Type{<:$type})
     LinearAlgebra.mul!(::AbstractMatrix, ::$type, ::$type, ::Number, ::Number)
   end


### PR DESCRIPTION
This is a slightly hacky way to bypass causing a lot of method invalidations. In particular, see the following issues:

https://github.com/ITensor/SparseArraysBase.jl/issues/25
https://github.com/ITensor/BlockSparseArrays.jl/issues/34

originally noticed during: https://github.com/ITensor/ITensors.jl/pull/1579