### PR TITLE
Revert changes to `cat` in `AbstractArrayOps`, introduce `cat_along`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DerivableInterfaces"
 uuid = "6c5e35bf-e59e-4898-b73c-732dcc4ba65f"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.3.11"
+version = "0.3.12"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/abstractarrayinterface.jl
+++ b/src/abstractarrayinterface.jl
@@ -324,6 +324,10 @@ end
   return a_dest
 end
 
+function cat_along(dims, as::AbstractArray...)
+  return @interface interface(as...) cat_along(dims, as...)
+end
+
 @interface interface::AbstractArrayInterface function cat_along(dims, as::AbstractArray...)
   a_dest = similar(Cat(as...; dims))
   @interface interface cat!(a_dest, as...; dims)

--- a/src/abstractarrayinterface.jl
+++ b/src/abstractarrayinterface.jl
@@ -324,10 +324,14 @@ end
   return a_dest
 end
 
-@interface interface::AbstractArrayInterface function Base._cat(dims, as::AbstractArray...)
+@interface interface::AbstractArrayInterface function cat_along(dims, as::AbstractArray...)
   a_dest = similar(Cat(as...; dims))
   @interface interface cat!(a_dest, as...; dims)
   return a_dest
+end
+
+@interface interface::AbstractArrayInterface function Base.cat(as::AbstractArray...; dims)
+  return @interface interface cat_along(dims, as...)
 end
 
 # TODO: Use `@derive` instead:

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -45,7 +45,7 @@ function derive(::Val{:AbstractArrayOps}, type)
     Base.permutedims!(::Any, ::$type, ::Any)
     Broadcast.BroadcastStyle(::Type{<:$type})
     Base.copyto!(::$type, ::Broadcast.Broadcasted{Broadcast.DefaultArrayStyle{0}})
-    Base._cat(::Any, ::$type...)
+    Base.cat(::$type...; kwargs...)
     ArrayLayouts.MemoryLayout(::Type{<:$type})
     LinearAlgebra.mul!(::AbstractMatrix, ::$type, ::$type, ::Number, ::Number)
   end


### PR DESCRIPTION
This reverts a breaking change to `AbstractArrayOps` introduced in #13, and reverts the removal of the interface version of `Base.cat`, which broke BlockSparseArrays.jl.

It also introduces a new interface function `cat_along(dims, as::AbstractArray...)` which is like `Base.cat(as::AbstractArray...; dims)` but where the dimensions are passed as the first argument (so basically the private Base function `Base._cat` with a nicer name). We can discuss the name and interface later, mostly it is meant as an initial proposal.