### PR TITLE
More customization points in `Concatenate`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DerivableInterfaces"
 uuid = "6c5e35bf-e59e-4898-b73c-732dcc4ba65f"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
@@ -13,9 +13,16 @@ MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078"
 MapBroadcast = "ebd9b9da-f48d-417c-9660-449667d60261"
 TypeParameterAccessors = "7e5a90cf-f82e-492e-a09b-e3e26432c138"
 
+[weakdeps]
+BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
+
+[extensions]
+DerivableInterfacesBlockArraysExt = "BlockArrays"
+
 [compat]
 Adapt = "4.1.1"
-ArrayLayouts = "1.11.0"
+ArrayLayouts = "1.11"
+BlockArrays = "1.4"
 Compat = "3.47,4.10"
 ExproniconLite = "0.10.13"
 LinearAlgebra = "1.10"

--- a/ext/DerivableInterfacesBlockArraysExt/DerivableInterfacesBlockArraysExt.jl
+++ b/ext/DerivableInterfacesBlockArraysExt/DerivableInterfacesBlockArraysExt.jl
@@ -1,0 +1,10 @@
+module DerivableInterfacesBlockArraysExt
+
+using BlockArrays: BlockedOneTo, blockedrange, blocklengths
+using DerivableInterfaces.Concatenate: Concatenate
+
+function Concatenate.cat_axis(a1::BlockedOneTo, a2::BlockedOneTo)
+  return blockedrange([blocklengths(a1); blocklengths(a2)])
+end
+
+end

--- a/src/concatenate.jl
+++ b/src/concatenate.jl
@@ -53,19 +53,13 @@ struct Concatenated{Interface,Dims,Args<:Tuple}
   end
 end
 
-function Concatenated(
-  interface::Union{Nothing,AbstractInterface},
-  dims::Val,
-  args::Tuple,
-)
+function Concatenated(interface::Union{Nothing,AbstractInterface}, dims::Val, args::Tuple)
   return _Concatenated(interface, dims, args)
 end
 function Concatenated(dims::Val, args::Tuple)
   return Concatenated(interface(args...), dims, args)
 end
-function Concatenated{Interface}(
-  dims::Val, args::Tuple
-) where {Interface}
+function Concatenated{Interface}(dims::Val, args::Tuple) where {Interface}
   return Concatenated(Interface(), dims, args)
 end
 

--- a/src/defaultarrayinterface.jl
+++ b/src/defaultarrayinterface.jl
@@ -30,3 +30,7 @@ end
 )
   return Base.mapreduce(f, op, as...; kwargs...)
 end
+
+function arraytype(::DefaultArrayInterface, T::Type)
+  return Array{T}
+end

--- a/src/zero.jl
+++ b/src/zero.jl
@@ -4,3 +4,7 @@
 In-place version of `Base.zero`.
 """
 function zero! end
+
+@derive (T=AbstractArray,) begin
+  DerivableInterfaces.zero!(::T)
+end

--- a/test/test_concatenate.jl
+++ b/test/test_concatenate.jl
@@ -1,0 +1,31 @@
+using DerivableInterfaces.Concatenate: concatenated
+using Test: @test, @testset
+
+@testset "Concatenated" begin
+  a = randn(Float32, 2, 2)
+  b = randn(Float64, 2, 2)
+
+  concat = concatenated((1, 2), a, b)
+  @test axes(concat) == Base.OneTo.((4, 4))
+  @test size(concat) == (4, 4)
+  @test eltype(concat) === Float64
+  @test copy(concat) == cat(a, b; dims=(1, 2))
+
+  concat = concatenated(1, a, b)
+  @test axes(concat) == Base.OneTo.((4, 2))
+  @test size(concat) == (4, 2)
+  @test eltype(concat) === Float64
+  @test copy(concat) == cat(a, b; dims=1)
+
+  concat = concatenated(3, a, b)
+  @test axes(concat) == Base.OneTo.((2, 2, 2))
+  @test size(concat) == (2, 2, 2)
+  @test eltype(concat) === Float64
+  @test copy(concat) == cat(a, b; dims=3)
+
+  concat = concatenated(4, a, b)
+  @test axes(concat) == Base.OneTo.((2, 2, 1, 2))
+  @test size(concat) == (2, 2, 1, 2)
+  @test eltype(concat) === Float64
+  @test copy(concat) == cat(a, b; dims=4)
+end


### PR DESCRIPTION
This is a followup to #18. In #18, the logic for determining the output shape is based on the `Base` logic, which is very `size`-oriented and doesn't allow for customization points for custom axes like blocked axes. This PR is meant to address that, which helps when implementing concatenation in BlockSparseArrays.jl (https://github.com/ITensor/BlockSparseArrays.jl/pull/84).